### PR TITLE
Fix error on green color computation

### DIFF
--- a/sgreader/sgimage.cpp
+++ b/sgreader/sgimage.cpp
@@ -402,7 +402,7 @@ void SgImage::set555Pixel(QImage *img, int x, int y, quint16 color) {
 	rgb |= ((color & 0x7c00) << 9) | ((color & 0x7000) << 4);
 	
 	// Green: bits 6-10, should go to bits 9-16
-	rgb |= ((color & 0x3e0) << 6) | ((color & 0x300));
+	rgb |= ((color & 0x3e0) << 6) | ((color & 0x300) << 1);
 	
 	// Blue: bits 1-5, should go to bits 1-8
 	rgb |= ((color & 0x1f) << 3) | ((color & 0x1c) >> 2);


### PR DESCRIPTION
Probably a typo, but there is an error in the Argb code computation, some bits should be shifted but are not.

```c
// 24 23 22 21 | 20 19 18 17 | 16 15 14 13 | 12 11 10 09 | 08 07 06 05 | 04 03 02 01                                 
//  0  0  0  0 |  0  0  0  0 |  0 r1 r2 r3 | r4 r5 g1 g2 | g3 g4 g5 b1 | b2 b3 b4 b5                                 
//  0  0  0  0 |  0  0  0  0 |  0  1  1  1 |  1  1  0  0 |  0  0  0  0 |  0  0  0  0 = 0x7c00                        
//  0  0  0  0 |  0  0  0  0 |  0  1  1  1 |  0  0  0  0 |  0  0  0  0 |  0  0  0  0 = 0x7000                        
//  1  1  1  1 |  1  1  1  1 |  0  0  0  0 |  0  0  0  0 |  0  0  0  0 |  0  0  0  0 = (0x7c00 << 9) | (0x7000 << 4) 
//  0  0  0  0 |  0  0  0  0 |  0  0  0  0 |  0  0  1  1 |  1  1  1  0 |  0  0  0  0 = 0x3e0                         
//  0  0  0  0 |  0  0  0  0 |  0  0  0  0 |  0  0  1  1 |  1  0  0  0 |  0  0  0  0 = 0x300                         
//  0  0  0  0 |  0  0  0  0 |  1  1  1  1 |  1  1  1  1 |  0  0  0  0 |  0  0  0  0 = (0x3e0 << 6) | (0x300 << 1)   
//  0  0  0  0 |  0  0  0  0 |  0  0  0  0 |  0  0  0  0 |  0  0  0  1 |  1  1  1  1 = 0x1f                          
//  0  0  0  0 |  0  0  0  0 |  0  0  0  0 |  0  0  0  0 |  0  0  0  1 |  1  1  0  0 = 0x1c                          
//  0  0  0  0 |  0  0  0  0 |  0  0  0  0 |  0  0  0  0 |  1  1  1  1 |  1  1  1  1 = (0x1f << 3) | (0x1c >> 2)     
```